### PR TITLE
chore: regenerate mise lock to fix CI issues

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -8,7 +8,15 @@ backend = "aqua:asciinema/agg"
 checksum = "sha256:4b22399a4a0882f8ac9585a27c5bda1dfd755e04a7a989505bc434d49f25434a"
 url = "https://github.com/asciinema/agg/releases/download/v1.7.0/agg-aarch64-unknown-linux-gnu"
 
+[tools."aqua:asciinema/agg"."platforms.linux-arm64-musl"]
+checksum = "sha256:4b22399a4a0882f8ac9585a27c5bda1dfd755e04a7a989505bc434d49f25434a"
+url = "https://github.com/asciinema/agg/releases/download/v1.7.0/agg-aarch64-unknown-linux-gnu"
+
 [tools."aqua:asciinema/agg"."platforms.linux-x64"]
+checksum = "sha256:593122aced7f11b367e397c06061eaadb7bd6ef7acde16832a3138d70105d26c"
+url = "https://github.com/asciinema/agg/releases/download/v1.7.0/agg-x86_64-unknown-linux-musl"
+
+[tools."aqua:asciinema/agg"."platforms.linux-x64-musl"]
 checksum = "sha256:593122aced7f11b367e397c06061eaadb7bd6ef7acde16832a3138d70105d26c"
 url = "https://github.com/asciinema/agg/releases/download/v1.7.0/agg-x86_64-unknown-linux-musl"
 
@@ -32,7 +40,15 @@ backend = "aqua:asciinema/asciinema"
 checksum = "sha256:f7f92769f7b4150df2835ddd4eda067b0786d0d734284a0f9c2aaa2514e8beb6"
 url = "https://github.com/asciinema/asciinema/releases/download/v3.2.0/asciinema-aarch64-unknown-linux-gnu"
 
+[tools."aqua:asciinema/asciinema"."platforms.linux-arm64-musl"]
+checksum = "sha256:f7f92769f7b4150df2835ddd4eda067b0786d0d734284a0f9c2aaa2514e8beb6"
+url = "https://github.com/asciinema/asciinema/releases/download/v3.2.0/asciinema-aarch64-unknown-linux-gnu"
+
 [tools."aqua:asciinema/asciinema"."platforms.linux-x64"]
+checksum = "sha256:34cf9ddb54df166878a213d5173af4d5f9df9564ab8b1054a080408bce0b720e"
+url = "https://github.com/asciinema/asciinema/releases/download/v3.2.0/asciinema-x86_64-unknown-linux-musl"
+
+[tools."aqua:asciinema/asciinema"."platforms.linux-x64-musl"]
 checksum = "sha256:34cf9ddb54df166878a213d5173af4d5f9df9564ab8b1054a080408bce0b720e"
 url = "https://github.com/asciinema/asciinema/releases/download/v3.2.0/asciinema-x86_64-unknown-linux-musl"
 
@@ -86,29 +102,29 @@ version = "3.14.3"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:be0f4dc2932f762292b27d46ea7d3e8e66ddf3969a5eb0254a229015ed402625"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:c4a5cc7681da3ed2066194f6fac24207a764db38f23fc5a2b1b56671ee3142d6"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 
 [tools.python."platforms.linux-arm64-musl"]
-checksum = "sha256:be0f4dc2932f762292b27d46ea7d3e8e66ddf3969a5eb0254a229015ed402625"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:c4a5cc7681da3ed2066194f6fac24207a764db38f23fc5a2b1b56671ee3142d6"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:0a73413f89efd417871876c9accaab28a9d1e3cd6358fbfff171a38ec99302f0"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:bc35984c271adb7b0d2f730eced89fbbb96246c4d716c415e4af7ed686627831"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 
 [tools.python."platforms.linux-x64-musl"]
-checksum = "sha256:0a73413f89efd417871876c9accaab28a9d1e3cd6358fbfff171a38ec99302f0"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:bc35984c271adb7b0d2f730eced89fbbb96246c4d716c415e4af7ed686627831"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:4703cdf18b26798fde7b49b6b66149674c25f97127be6a10dbcf29309bdcdcdb"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:f9b4a94d2d62ca77e08873b861b8cd989eda922ad3c3eafd2dfad57375e6ae61"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-aarch64-apple-darwin-install_only_stripped.tar.gz"
 
 [tools.python."platforms.macos-x64"]
-checksum = "sha256:76f1cc26e3d262eae8ca546a93e8bded10cf0323613f7e246fea2e10a8115eb7"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:cb8d27660e0575d33c6828c4f73c891a005d8cfade8941d889fd0efd0ff031dc"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-apple-darwin-install_only_stripped.tar.gz"
 
 [tools.python."platforms.windows-x64"]
-checksum = "sha256:950c5f21a015c1bdd1337f233456df2470fab71e4d794407d27a84cb8b9909a0"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+checksum = "sha256:2223000d2dcce0f50a8feddb8a8391ec6e5534f6f7169e10004a11ce9b438ed3"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"


### PR DESCRIPTION
mise ERROR Failed to install core:python@3.14.3: Checksum mismatch for file ~/.local/share/mise/downloads/python/3.14.3/cpython-3.14.3+20260320-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz:
Expected: sha256:0a73413f89efd417871876c9accaab28a9d1e3cd6358fbfff171a38ec99302f0
Actual:   sha256:bc35984c271adb7b0d2f730eced89fbbb96246c4d716c415e4af7ed686627831

- https://github.com/iglootools/nbkp/actions/runs/23417379863/job/68115513538
- https://github.com/iglootools/nbkp/actions/runs/23417379856/job/68115493300