### PR TITLE
fix(ci): pin publish checkout to the release workflow's head SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
         fetch-depth: 0
         fetch-tags: true
     - uses: jdx/mise-action@v4


### PR DESCRIPTION
## Summary
- The `publish` workflow's `workflow_run` trigger was checking out the default branch HEAD instead of the tagged commit. If anything landed on `main` between the `release` workflow finishing and `publish` starting, the built package wouldn't match the tag (and `poetry-dynamic-versioning` could derive an unexpected version).
- Pin `actions/checkout` to `github.event.workflow_run.head_sha` (the commit the `release` workflow ran on, which is the commit `mathieudutour/github-tag-action` tagged), falling back to `github.sha` for the other triggers (`push: tags`, `workflow_dispatch`).
- `publish-test.yml` is unchanged — it only runs via `workflow_dispatch`, where the default ref is already correct.

## Test plan
- [ ] Trigger the `release` workflow and confirm the subsequent `publish` run checks out the tagged SHA (visible in the checkout step logs).
- [ ] Re-trigger `publish` manually via `gh workflow run publish.yml --ref <tag>` and confirm checkout still resolves to the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)